### PR TITLE
Insert RB750GL as CapsMan configuration

### DIFF
--- a/telegraf.d/rb750GL-capsman.conf
+++ b/telegraf.d/rb750GL-capsman.conf
@@ -1,0 +1,158 @@
+# # Retrieves SNMP values from remote agents
+[[inputs.snmp]]
+#   ## Agent addresses to retrieve values from.
+#   ##   example: agents = ["udp://127.0.0.1:161"]
+#   ##            agents = ["tcp://127.0.0.1:161"]
+   agents = ["udp://192.168.1.1:161"]
+  
+  [[inputs.snmp.field]]
+    name = "hostname"
+    oid = ".1.3.6.1.2.1.1.5.0"
+    is_tag = true
+  [[inputs.snmp.field]]
+    name = "uptime"
+    oid = ".1.3.6.1.2.1.1.3.0"
+  [[inputs.snmp.field]]
+    name = "cpu-frequency"
+    oid = ".1.3.6.1.4.1.14988.1.1.3.14.0"
+  [[inputs.snmp.field]]
+    name = "cpu-load"
+    oid = ".1.3.6.1.2.1.25.3.3.1.2.1"
+  [[inputs.snmp.field]]
+    name = "active-fan"
+    oid = ".1.3.6.1.4.1.14988.1.1.3.9.0"
+  [[inputs.snmp.field]]
+    name = "voltage"
+    oid = ".1.3.6.1.4.1.14988.1.1.3.8.0"
+  [[inputs.snmp.field]]
+    name = "temperature"
+    oid = ".1.3.6.1.4.1.14988.1.1.3.10.0"
+  [[inputs.snmp.field]]
+    name = "processor-temperature"
+    oid = ".1.3.6.1.4.1.14988.1.1.3.11.0"
+  [[inputs.snmp.field]]
+    name = "current"
+    oid = ".1.3.6.1.4.1.14988.1.1.3.13.0"
+  [[inputs.snmp.field]]
+    name = "fan-speed"
+    oid = ".1.3.6.1.4.1.14988.1.1.3.17.0"
+  [[inputs.snmp.field]]
+    name = "fan-speed2"
+    oid = ".1.3.6.1.4.1.14988.1.1.3.18.0"
+  [[inputs.snmp.field]]
+    name = "power-consumption"
+    oid = ".1.3.6.1.4.1.14988.1.1.3.12.0"
+  [[inputs.snmp.field]]
+    name = "psu1-state"
+    oid = ".1.3.6.1.4.1.14988.1.1.3.15.0"
+  [[inputs.snmp.field]]
+    name = "psu2-state"
+    oid = ".1.3.6.1.4.1.14988.1.1.3.16.0"
+
+# Interfaces
+  [[inputs.snmp.table]]
+    name = "snmp-interfaces"
+    inherit_tags = ["hostname"]
+    [[inputs.snmp.table.field]]
+      name = "if-name"
+      oid = ".1.3.6.1.2.1.2.2.1.2"
+      is_tag = true
+    [[inputs.snmp.table.field]]
+      name = "mac-address"
+      oid = ".1.3.6.1.2.1.2.2.1.6"
+      is_tag = true
+
+    [[inputs.snmp.table.field]]
+      name = "actual-mtu"
+      oid = ".1.3.6.1.2.1.2.2.1.4"
+    [[inputs.snmp.table.field]]
+      name = "admin-status"
+      oid = ".1.3.6.1.2.1.2.2.1.7"
+    [[inputs.snmp.table.field]]
+      name = "oper-status"
+      oid = ".1.3.6.1.2.1.2.2.1.8"
+    [[inputs.snmp.table.field]]
+      name = "bytes-in"
+      oid = ".1.3.6.1.2.1.31.1.1.1.6"
+    [[inputs.snmp.table.field]]
+      name = "packets-in"
+      oid = ".1.3.6.1.2.1.31.1.1.1.7"
+    [[inputs.snmp.table.field]]
+      name = "discards-in"
+      oid = ".1.3.6.1.2.1.2.2.1.13"
+    [[inputs.snmp.table.field]]
+      name = "errors-in"
+      oid = ".1.3.6.1.2.1.2.2.1.14"
+    [[inputs.snmp.table.field]]
+      name = "bytes-out"
+      oid = ".1.3.6.1.2.1.31.1.1.1.10"
+    [[inputs.snmp.table.field]]
+      name = "packets-out"
+      oid = ".1.3.6.1.2.1.31.1.1.1.11"
+    [[inputs.snmp.table.field]]
+      name = "discards-out"
+      oid = ".1.3.6.1.2.1.2.2.1.19"
+    [[inputs.snmp.table.field]]
+      name= "errors-out"
+      oid= ".1.3.6.1.2.1.2.2.1.20"
+
+# Wireless interfaces
+  [[inputs.snmp.table]]
+    name = "snmp-wireless-interfaces"
+    inherit_tags = ["hostname"]
+    [[inputs.snmp.table.field]]
+      name = "ssid"
+      oid = ".1.3.6.1.4.1.14988.1.1.1.5.1.12"
+      is_tag = true
+    [[inputs.snmp.table.field]]
+      name = "bssid"
+      oid = ".1.3.6.1.4.1.14988.1.1.1.5.1.13"
+      is_tag = true
+    [[inputs.snmp.table.field]]
+      name = "mac"
+      oid = ".1.3.6.1.4.1.14988.1.1.1.5.1.1"
+      is_tag = true
+      conversion = "hwaddr"
+    
+    [[inputs.snmp.table.field]]
+      name = "tx-rate"
+      oid = ".1.3.6.1.4.1.14988.1.1.1.5.1.8"
+    [[inputs.snmp.table.field]]
+      name = "rx-rate"
+      oid = ".1.3.6.1.4.1.14988.1.1.1.5.1.9"
+    [[inputs.snmp.table.field]]
+      name = "client-count"
+      oid = ".1.3.6.1.4.1.14988.1.1.1.6.0"
+    [[inputs.snmp.table.field]]
+      name = "tx-signal"
+      oid = ".1.3.6.1.4.1.14988.1.1.1.5.1.10"
+    [[inputs.snmp.table.field]]                                                                                                                                                                        
+      name = "rx-signal"                                                                                                                                                                               
+      oid = ".1.3.6.1.4.1.14988.1.1.1.5.1.11" 
+    [[inputs.snmp.table.field]]
+      name = "tx-bytes"
+      oid = ".1.3.6.1.4.1.14988.1.1.1.5.1.4"
+    [[inputs.snmp.table.field]]                                                                                                                                                                        
+      name = "rx-bytes"                                                                                                                                                                          
+      oid = ".1.3.6.1.4.1.14988.1.1.1.5.1.5"
+    [[inputs.snmp.table.field]]
+      name = "uptime"
+      oid = ".1.3.6.1.4.1.14988.1.1.1.5.1.3"
+	
+
+# Memory usage (storage/RAM)
+  [[inputs.snmp.table]]
+    name = "snmp-memory-usage"
+    inherit_tags = ["hostname"]
+  [[inputs.snmp.table.field]]
+      name = "memory-name"
+      oid = ".1.3.6.1.2.1.25.2.3.1.3"
+      is_tag = true
+  [[inputs.snmp.table.field]]
+      name = "total-memory"
+      oid = ".1.3.6.1.2.1.25.2.3.1.5"
+  [[inputs.snmp.table.field]]
+      name = "used-memory"
+      oid = ".1.3.6.1.2.1.25.2.3.1.6"
+
+


### PR DESCRIPTION
This is based on rb2011uias.conf but removed wireless info (not
supported by RB750GL) and added CapsMan OID instead. Not all parameters
are available (like ccq) for CapsMan.

Signed-off-by: Josenivaldo Benito Jr <jrbenito@benito.qsl.br>